### PR TITLE
Must use new QBE

### DIFF
--- a/fw/install.sh
+++ b/fw/install.sh
@@ -7,8 +7,9 @@ SRC_DIR="${PREFIX}/src"
 
 QBE_OK=1
 FORCE_FALLBACK=0
-QBE_MIRROR_REPO="https://github.com/8l/qbe.git"
-QBE_REPO="https://c9x.me/git/qbe.git"
+#QBE_MIRROR_REPO="https://github.com/8l/qbe.git"
+QBE_REPO="git://c9x.me/qbe.git"
+QBE_MIRROR_REPO="git://c9x.me/qbe.git"
 SPECTRE_REPO="https://github.com/spectrelang/spectre.git"
 YYJSON_REPO="https://github.com/ibireme/yyjson.git"
 


### PR DESCRIPTION
https://github.com/8l/qbe.git is too old (9 year hav't update)  
I use this qbe will failed install and can't build sx file had more error  
use new qbe is ok when build samples, so remove https://github.com/8l/qbe.git pls